### PR TITLE
docs(worker): fix encoding artifacts and align retry semantics

### DIFF
--- a/docs/docs/api/worker.md
+++ b/docs/docs/api/worker.md
@@ -26,9 +26,10 @@ Methods:
 
 Timeouts:
 
-- If `task_timeout` > 0, tasks execute in a helper thread and are marked failed if they exceed the timeout (thread isn’t forcibly killed).
+- If `task_timeout` > 0, tasks execute in a helper thread and are marked failed if they exceed the timeout (the thread isn't forcibly killed).
 
 Retries:
 
-- Failures are retried while attempts ≤ `max_retries` using `RetryPolicy.compute_delay`.
+- Failures are retried while attempts <= `max_retries` using `RetryPolicy.compute_delay`.
+
 


### PR DESCRIPTION
  Fixes corrupted characters in docs/docs/api/worker.md and clarifies behavior to match the implementation:

  - Replace mojibake in timeouts section (“thread isn�?Tt forcibly killed”) with “the thread isn't forcibly killed”.
  - Clarify retry condition to “attempts <= max_retries” consistent with Worker logic.